### PR TITLE
add newline to course links

### DIFF
--- a/src/components/Course.js
+++ b/src/components/Course.js
@@ -50,6 +50,7 @@ class Course extends React.Component {
       return (
         <div className="inset">
             <a href={moreInformation.reviewLink} target="_blank">Course reviews</a>
+            <br>
             <a href={moreInformation.wikiLink} target="_blank">Course Wiki</a>
         </div>
       )


### PR DESCRIPTION
This prevents the two links from rendering right next to each other and looks much cleaner.

Before : 

<img width="1440" alt="screen shot 2018-08-01 at 5 11 43 pm" src="https://user-images.githubusercontent.com/4019054/43549302-3cb1ff20-95ae-11e8-9ff8-f18089782b54.png">


After: 🔥 

<img width="1440" alt="screen shot 2018-08-01 at 5 12 01 pm" src="https://user-images.githubusercontent.com/4019054/43549333-50e246b2-95ae-11e8-86ff-e617b5459d14.png">

